### PR TITLE
get all public memories by userId

### DIFF
--- a/mnemosyne/pom.xml
+++ b/mnemosyne/pom.xml
@@ -79,6 +79,4 @@
         </dependency>
     </dependencies>
 
-
-
 </project>

--- a/mnemosyne/src/main/java/com/boun/swe/mnemosyne/config/DataLoader.java
+++ b/mnemosyne/src/main/java/com/boun/swe/mnemosyne/config/DataLoader.java
@@ -1,0 +1,68 @@
+package com.boun.swe.mnemosyne.config;
+
+import com.boun.swe.mnemosyne.enums.MemoryType;
+import com.boun.swe.mnemosyne.enums.Role;
+import com.boun.swe.mnemosyne.model.Location;
+import com.boun.swe.mnemosyne.model.Memory;
+import com.boun.swe.mnemosyne.model.User;
+import com.boun.swe.mnemosyne.repository.MemoryRepository;
+import com.boun.swe.mnemosyne.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.util.Collections;
+import java.util.Date;
+
+@Component
+public class DataLoader {
+
+    private UserRepository userRepository;
+    private MemoryRepository memoryRepository;
+
+    @Autowired
+    public DataLoader(UserRepository userRepository, MemoryRepository memoryRepository) {
+        this.userRepository = userRepository;
+        this.memoryRepository = memoryRepository;
+    }
+
+    @PostConstruct
+    public void loadData() {
+        User user = User.builder()
+                .id(1L)
+                .email("test@example.com")
+                .password("12345")
+                .role(Role.ADMIN)
+                .username("admin")
+                .build();
+
+        userRepository.save(user);
+
+        Memory privateMemory = Memory.builder()
+                .id(1L)
+                .title("70's Berlin")
+                .text("there was a wall!")
+                .dateFrom(new Date(100_000_000))
+                .dateTo(new Date(150_000_000))
+                .isPublished(true)
+                .locations(Collections.singleton(new Location(1L, "Berlin", 52.520008, 13.404954, Collections.emptySet())))
+                .type(MemoryType.PUBLIC)
+                .user(user)
+                .build();
+
+        Memory publicMemory = Memory.builder()
+                .id(2L)
+                .title("90's Berlin")
+                .text("wall is gone!")
+                .dateFrom(new Date(100_000_000))
+                .dateTo(new Date(150_000_000))
+                .isPublished(true)
+                .locations(Collections.singleton(new Location(1L, "Berlin", 52.520008, 13.404954, Collections.emptySet())))
+                .type(MemoryType.PRIVATE)
+                .user(user)
+                .build();
+
+        memoryRepository.save(publicMemory);
+        memoryRepository.save(privateMemory);
+    }
+}

--- a/mnemosyne/src/main/java/com/boun/swe/mnemosyne/controller/MemoryController.java
+++ b/mnemosyne/src/main/java/com/boun/swe/mnemosyne/controller/MemoryController.java
@@ -13,6 +13,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -54,6 +55,14 @@ public class MemoryController {
         LOGGER.info("Get all public memories request received");
         List<Memory> memories = memoryService.getAllPublicMemories();
         model.addAttribute("publicMemories", memories);
+        return "memories";
+    }
+
+    @GetMapping(value = "/user/{userId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public String getAllPublicMemoriesByUser(@PathVariable("userId") final Long userId, final Model model) {
+        LOGGER.info("Get all public memories request received");
+        List<Memory> memories = memoryService.getAllPublicMemoriesByUser(userId);
+        model.addAttribute("userPublicMemories", memories);
         return "memories";
     }
 }

--- a/mnemosyne/src/main/java/com/boun/swe/mnemosyne/model/Location.java
+++ b/mnemosyne/src/main/java/com/boun/swe/mnemosyne/model/Location.java
@@ -1,6 +1,8 @@
 package com.boun.swe.mnemosyne.model;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.Column;
@@ -16,6 +18,8 @@ import java.util.Set;
 
 @Getter
 @Setter
+@AllArgsConstructor
+@NoArgsConstructor
 @Entity
 @Table(name = "locations")
 public class Location {

--- a/mnemosyne/src/main/java/com/boun/swe/mnemosyne/model/Memory.java
+++ b/mnemosyne/src/main/java/com/boun/swe/mnemosyne/model/Memory.java
@@ -2,9 +2,12 @@ package com.boun.swe.mnemosyne.model;
 
 
 import com.boun.swe.mnemosyne.enums.MemoryType;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.CascadeType;
@@ -30,6 +33,9 @@ import java.util.Set;
 @Getter
 @Setter
 @EqualsAndHashCode
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
 @Builder
 @Entity
 @Table(name = "memories")

--- a/mnemosyne/src/main/java/com/boun/swe/mnemosyne/model/User.java
+++ b/mnemosyne/src/main/java/com/boun/swe/mnemosyne/model/User.java
@@ -1,7 +1,10 @@
 package com.boun.swe.mnemosyne.model;
 
 import com.boun.swe.mnemosyne.enums.Role;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.validator.constraints.Email;
 
@@ -16,6 +19,9 @@ import javax.persistence.Table;
 
 @Getter
 @Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 @Entity
 @Table(name = "user")
 public class User {

--- a/mnemosyne/src/main/java/com/boun/swe/mnemosyne/repository/MemoryRepository.java
+++ b/mnemosyne/src/main/java/com/boun/swe/mnemosyne/repository/MemoryRepository.java
@@ -3,6 +3,7 @@ package com.boun.swe.mnemosyne.repository;
 import com.boun.swe.mnemosyne.enums.MemoryType;
 import com.boun.swe.mnemosyne.model.Memory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,4 +11,7 @@ import java.util.List;
 @Repository
 public interface MemoryRepository extends JpaRepository<Memory, Long> {
     List<Memory> findByTypeAndIsPublishedTrue(final MemoryType type);
+
+    @Query(value = "SELECT m FROM Memory m where m.type = ?1 and m.user.id = ?2")
+    List<Memory> findAllMemoriesByTypeAndUserId(final MemoryType memoryType, final Long userId);
 }

--- a/mnemosyne/src/main/java/com/boun/swe/mnemosyne/service/MemoryService.java
+++ b/mnemosyne/src/main/java/com/boun/swe/mnemosyne/service/MemoryService.java
@@ -7,6 +7,7 @@ import com.boun.swe.mnemosyne.repository.MemoryRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Example;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -36,13 +37,19 @@ public class MemoryService {
     }
 
     public Memory updateMemory(Memory memory) {
-        if (!memoryRepository.exists(memory.getId())) {
+        if (!memoryRepository.exists(Example.of(memory))) {
             LOGGER.warn("Unable to update memory with id: {} and title: {}",
                     memory.getId(), memory.getTitle());
             throw new MemoryNotFoundException("Unable to find memory with id: " + memory.getId());
         }
         final Memory storedMemory = memoryRepository.save(memory);
-         LOGGER.info("Memory with title: {} created successfully", memory.getTitle());
+        LOGGER.info("Memory with title: {} updated successfully", memory.getTitle());
         return storedMemory;
+    }
+
+    public List<Memory> getAllPublicMemoriesByUser(Long userId) {
+        List<Memory> memories = memoryRepository.findAllMemoriesByTypeAndUserId(MemoryType.PUBLIC, userId);
+        LOGGER.info("Memories with userId: {} retrieved successfully", userId);
+        return memories;
     }
 }


### PR DESCRIPTION
this branch includes followings:

**- an endpoint to retrieve all public memories of a user** 
 
**endpoint:**
<<host:port>>/memories/user/{userId}
localhost/8090/memories/user/1

**- also introducing a DataLoader class under config folder, which creates 1 user and 2 memories (1 public & private) at application startup. You can use them as a testing data.** 
- These users will be deleted or passwords can be read from config folder

**- Examples:**
user:
(id: 1, email: test@example.com, username: admin, password: 12345)

memories:
(id: 1, text: "70's Berlin", type: private, userId: 1), 
(id: 2, text: "90's Berlin", type: public, userId: 1)

