### PR TITLE
Feature/vedat/inquire memories of following

### DIFF
--- a/mnemosyne/src/main/java/com/boun/swe/mnemosyne/controller/MemoryController.java
+++ b/mnemosyne/src/main/java/com/boun/swe/mnemosyne/controller/MemoryController.java
@@ -90,8 +90,7 @@ public class MemoryController {
         return "memories";
     }
 
-    private List<Memory> findRequestedMemories(@PathVariable("userId") Long userId,
-                                               @RequestParam("memoryType") String memoryType, User userInRequest) {
+    private List<Memory> findRequestedMemories(Long userId, String memoryType, User userInRequest) {
         List<Memory> memories;
         if (userInRequest != null && userInRequest.getId() == userId) {
             switch (memoryType) {

--- a/mnemosyne/src/main/java/com/boun/swe/mnemosyne/controller/MemoryController.java
+++ b/mnemosyne/src/main/java/com/boun/swe/mnemosyne/controller/MemoryController.java
@@ -77,7 +77,7 @@ public class MemoryController {
         return "memories";
     }
 
-    @GetMapping(value = "/followings/memories", produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(value = "/friendships/memories", produces = MediaType.APPLICATION_JSON_VALUE)
     public String getFollowingsMemories(final Principal principal, final Model model) {
         User user = userService.findByUsername(principal.getName());
         LOGGER.info("Get memories of followings request received for user: {}", user.getId());

--- a/mnemosyne/src/main/java/com/boun/swe/mnemosyne/controller/MemoryController.java
+++ b/mnemosyne/src/main/java/com/boun/swe/mnemosyne/controller/MemoryController.java
@@ -1,7 +1,10 @@
 package com.boun.swe.mnemosyne.controller;
 
+import com.boun.swe.mnemosyne.enums.MemoryType;
 import com.boun.swe.mnemosyne.model.Memory;
+import com.boun.swe.mnemosyne.model.User;
 import com.boun.swe.mnemosyne.service.MemoryService;
+import com.boun.swe.mnemosyne.service.UserService;
 import org.hibernate.validator.constraints.NotBlank;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,25 +19,31 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import javax.validation.constraints.NotNull;
+import java.security.Principal;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Validated
 @Controller
-@RequestMapping("/memories")
+@RequestMapping
 public class MemoryController {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MemoryController.class);
 
-    private MemoryService memoryService;
+    private final MemoryService memoryService;
+    private final UserService userService;
 
     @Autowired
-    public MemoryController(MemoryService memoryService) {
+    public MemoryController(MemoryService memoryService, UserService userService) {
         this.memoryService = memoryService;
+        this.userService = userService;
     }
 
-    @PostMapping(value = "/create", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(value = "/memories/create", produces = MediaType.APPLICATION_JSON_VALUE)
     public String createMemory(@ModelAttribute("memoryTitle") @NotBlank final String title, final Model model) {
         LOGGER.info("Create memory request received with memory title: {}", title);
         Memory createdMemory = memoryService.createMemory(Memory.builder().title(title).build());
@@ -42,7 +51,7 @@ public class MemoryController {
         return "memories";
     }
 
-    @PatchMapping(value = "/create", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @PatchMapping(value = "/memories/update", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public String patchUpdateMemory(@ModelAttribute("memoryForm") @NotNull final Memory memory, final Model model) {
         LOGGER.info("Create memory request received with memory title: {}", memory.getTitle());
         Memory updatedMemory = memoryService.updateMemory(memory);
@@ -50,19 +59,58 @@ public class MemoryController {
         return "memories";
     }
 
-    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(value = "/memories", produces = MediaType.APPLICATION_JSON_VALUE)
     public String getAllPublicMemories(final Model model) {
         LOGGER.info("Get all public memories request received");
-        List<Memory> memories = memoryService.getAllPublicMemories();
+        List<Memory> memories = memoryService.getAllMemoriesByType(MemoryType.PUBLIC);
         model.addAttribute("publicMemories", memories);
         return "memories";
     }
 
-    @GetMapping(value = "/user/{userId}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public String getAllPublicMemoriesByUser(@PathVariable("userId") final Long userId, final Model model) {
-        LOGGER.info("Get all public memories request received");
-        List<Memory> memories = memoryService.getAllPublicMemoriesByUser(userId);
+    @GetMapping(value = "/user/{userId}/memories", produces = MediaType.APPLICATION_JSON_VALUE)
+    public String getMemoriesByUser(@PathVariable("userId") final Long userId, @RequestParam("memoryType") final String memoryType,
+                                    final Principal principal, final Model model) {
+        LOGGER.info("Get memories request received by userId: {} with memoryType: {}", userId, memoryType);
+        User user = userService.findByUsername(principal.getName());
+        final List<Memory> memories = findRequestedMemories(userId, memoryType, user);
         model.addAttribute("userPublicMemories", memories);
         return "memories";
+    }
+
+    @GetMapping(value = "/followings/memories", produces = MediaType.APPLICATION_JSON_VALUE)
+    public String getFollowingsMemories(final Principal principal, final Model model) {
+        User user = userService.findByUsername(principal.getName());
+        LOGGER.info("Get memories of followings request received for user: {}", user.getId());
+        Set<Memory> followingsMemories = new HashSet<>();
+        user.getFollowingUsers().forEach(followingUser -> {
+            followingsMemories.addAll(memoryService.getAllMemoriesByTypeAndUser(MemoryType.PUBLIC, followingUser.getId()));
+            followingsMemories.addAll(memoryService.getAllMemoriesByTypeAndUser(MemoryType.SOCIAL, followingUser.getId()));
+        });
+        model.addAttribute("followingsMemories", followingsMemories);
+        return "memories";
+    }
+
+    private List<Memory> findRequestedMemories(@PathVariable("userId") Long userId,
+                                               @RequestParam("memoryType") String memoryType, User userInRequest) {
+        List<Memory> memories;
+        if (userInRequest != null && userInRequest.getId() == userId) {
+            switch (memoryType) {
+                case "public":
+                    memories = memoryService.getAllMemoriesByTypeAndUser(MemoryType.PUBLIC, userId);
+                    break;
+                case "social":
+                    memories = memoryService.getAllMemoriesByTypeAndUser(MemoryType.SOCIAL, userId);
+                    break;
+                case "private":
+                    memories = memoryService.getAllMemoriesByTypeAndUser(MemoryType.PRIVATE, userId);
+                    break;
+                default:
+                    memories = memoryService.getAllMemoriesByUser(userId);
+                    break;
+            }
+        } else {
+            memories = memoryService.getAllMemoriesByTypeAndUser(MemoryType.PUBLIC, userId);
+        }
+        return memories;
     }
 }

--- a/mnemosyne/src/main/java/com/boun/swe/mnemosyne/repository/MemoryRepository.java
+++ b/mnemosyne/src/main/java/com/boun/swe/mnemosyne/repository/MemoryRepository.java
@@ -10,7 +10,11 @@ import java.util.List;
 
 @Repository
 public interface MemoryRepository extends JpaRepository<Memory, Long> {
+
     List<Memory> findByTypeAndIsPublishedTrue(final MemoryType type);
+
+    @Query(value = "SELECT m FROM Memory m where m.user.id = ?1")
+    List<Memory> findAllMemoriesByUserId(final Long userId);
 
     @Query(value = "SELECT m FROM Memory m where m.type = ?1 and m.user.id = ?2")
     List<Memory> findAllMemoriesByTypeAndUserId(final MemoryType memoryType, final Long userId);

--- a/mnemosyne/src/main/java/com/boun/swe/mnemosyne/service/MemoryService.java
+++ b/mnemosyne/src/main/java/com/boun/swe/mnemosyne/service/MemoryService.java
@@ -31,11 +31,6 @@ public class MemoryService {
         return storedMemory;
     }
 
-    public List<Memory> getAllPublicMemories() {
-        LOGGER.info("Retrieving all published public memories");
-        return memoryRepository.findByTypeAndIsPublishedTrue(MemoryType.PUBLIC);
-    }
-
     public Memory updateMemory(Memory memory) {
         if (!memoryRepository.exists(Example.of(memory))) {
             LOGGER.warn("Unable to update memory with id: {} and title: {}",
@@ -47,9 +42,18 @@ public class MemoryService {
         return storedMemory;
     }
 
-    public List<Memory> getAllPublicMemoriesByUser(Long userId) {
-        List<Memory> memories = memoryRepository.findAllMemoriesByTypeAndUserId(MemoryType.PUBLIC, userId);
-        LOGGER.info("Memories with userId: {} retrieved successfully", userId);
-        return memories;
+    public List<Memory> getAllMemoriesByType(final MemoryType memoryType) {
+        LOGGER.info("Retrieving all published memories by memoryType: {}", memoryType.name());
+        return memoryRepository.findByTypeAndIsPublishedTrue(memoryType);
+    }
+
+    public List<Memory> getAllMemoriesByUser(final Long userId) {
+        LOGGER.info("Retrieving all published memories by memoryType: {}");
+        return memoryRepository.findAllMemoriesByUserId(userId);
+    }
+
+    public List<Memory> getAllMemoriesByTypeAndUser(final MemoryType memoryType, final Long userId) {
+        LOGGER.info("Retrieving all published memories by memoryType: {} for userId: {}", memoryType.name(), userId);
+        return memoryRepository.findByTypeAndIsPublishedTrue(memoryType);
     }
 }


### PR DESCRIPTION
Added the following endpoint:
- /friendships/memories --> will retrieve memories of logged-in user's followings

After the update below mappings will retrieve logged-in user's memories by memoryType
- /user/{userId}/memories?memoryType=public    --> only public memories
- /user/{userId}/memories?memoryType=private   --> only private memories
- /user/{userId}/memories?memoryType=social     --> only social memories
- /user/{userId}/memories                                         --> all memories

When userId in the path doesn't match with the user who makes the request, then only the public memories of requesting user will return.

This stays the same:
- /memories --> all public memories (regardless of user, can be used in index page)

