### PR TITLE
Fix/vedat/initial memory type private

### DIFF
--- a/mnemosyne/src/main/java/com/boun/swe/mnemosyne/controller/MemoryController.java
+++ b/mnemosyne/src/main/java/com/boun/swe/mnemosyne/controller/MemoryController.java
@@ -81,7 +81,6 @@ public class MemoryController {
         }
 
         validateMemoryByUser(model, user, memory);
-        model.addAttribute("memory", memory);
         return "memories";
     }
 
@@ -132,20 +131,34 @@ public class MemoryController {
     }
 
     private void validateMemoryByUser(Model model, User user, Memory memory) {
+
+        if (memory.getType().equals(MemoryType.PUBLIC)) {
+            model.addAttribute("memory", memory);
+            return;
+        }
+
+        if (user == null) {
+            final String errorMsg =
+                    String.format("Memory: %s is not available to unregistered user", memory.getId());
+            model.addAttribute("memoryNotAvailable", errorMsg);
+        }
+
         if (memory.getType().equals(MemoryType.PRIVATE)) {
             if (user.equals(memory.getUser())) {
                 model.addAttribute("memory", memory);
+                return;
             }
-        } else if (memory.getType().equals(MemoryType.PUBLIC)) {
-            model.addAttribute("memory", memory);
-        } else if (memory.getType().equals(MemoryType.SOCIAL)) {
+        }
+
+        if (memory.getType().equals(MemoryType.SOCIAL)) {
             if (user.getFollowingUsers().contains(memory.getUser())) {
                 model.addAttribute("memory", memory);
+                return;
             }
-        } else {
-            final String errorMsg = String.format("Memory is not available for the user: %s", user.getId());
-            LOGGER.warn(errorMsg);
-            model.addAttribute("memoryNotFound", errorMsg);
         }
+
+        final String errorMsg = String.format(
+                "User: %s has no access to memoryId: %s" + user.getUsername(), user.getId());
+        model.addAttribute("memoryNotAvailable", errorMsg);
     }
 }

--- a/mnemosyne/src/main/java/com/boun/swe/mnemosyne/controller/MemoryController.java
+++ b/mnemosyne/src/main/java/com/boun/swe/mnemosyne/controller/MemoryController.java
@@ -141,6 +141,7 @@ public class MemoryController {
             final String errorMsg =
                     String.format("Memory: %s is not available to unregistered user", memory.getId());
             model.addAttribute("memoryNotAvailable", errorMsg);
+            return;
         }
 
         if (memory.getType().equals(MemoryType.PRIVATE)) {

--- a/mnemosyne/src/main/java/com/boun/swe/mnemosyne/service/MemoryService.java
+++ b/mnemosyne/src/main/java/com/boun/swe/mnemosyne/service/MemoryService.java
@@ -56,4 +56,9 @@ public class MemoryService {
         LOGGER.info("Retrieving all published memories by memoryType: {} for userId: {}", memoryType.name(), userId);
         return memoryRepository.findByTypeAndIsPublishedTrue(memoryType);
     }
+
+    public Memory getMemoryById(final Long memoryId) {
+        LOGGER.info("Retrieving memory by id: {}", memoryId);
+        return memoryRepository.findOne(memoryId);
+    }
 }


### PR DESCRIPTION
**Endpoint to get memory by memoryId**
- If memory type is PUBLIC, then everyone can retrieve it
- If memory type is PRIVATE, then only the owner of memory can see it
- If memory type is SOCIAL, then only the owner and follower of this user can see it

**Fixing the following issue:**
- Memory type will be PRIVATE on memory creation since it will require PATCH update, due to some reasons when the user doesn't continue updating memory after setting the title, this memory shouldn't be returned in PUBLIC memories list