### PR TITLE
Fix image upload problem

### DIFF
--- a/mnemosyne/src/main/resources/static/js/addmemory.js
+++ b/mnemosyne/src/main/resources/static/js/addmemory.js
@@ -9,7 +9,7 @@ var options = {
          toolbar: [
              [{ header: [1, 2, false] }],
              ['bold', 'italic', 'underline'],
-             ['image', 'code-block']
+             ['code-block']
          ]
 //        toolbar: false,
     },


### PR DESCRIPTION
Fixed image upload byte issue by disabling image upload from the device. Images still work with copying from outer sources.